### PR TITLE
Typos fixed

### DIFF
--- a/lib/cjdb.js
+++ b/lib/cjdb.js
@@ -370,7 +370,7 @@ class Databridge{
      * reqested cache belongs to.
      * @returns {string}
      */
-    _genereateCachePath(sourceName, streamName){
+    _generateCachePath(sourceName, streamName){
         return this.option('cacheDir') + sourceName + '.' + streamName + '.json';
     }
 }

--- a/lib/cjdb.js
+++ b/lib/cjdb.js
@@ -80,7 +80,7 @@ const moment = require('moment');
 //
 
 /**
- * A data fetcer callback should fetch the data for a given data source, and
+ * A data fetcher callback should fetch the data for a given data source, and
  * return it in the form of a plain object that can be serialised to a JSON
  * string.
  * @callback DataFetcherCallback
@@ -212,7 +212,7 @@ class Databridge{
         }]);
         
         /**
-         * A plain object of option definitons.
+         * A plain object of option definitions.
          * @private
          * @type {PlainObject}
          */
@@ -250,7 +250,7 @@ class Databridge{
      * A function for adding a data source to the bridge.
      *
      * @param {Databridge.Datasource} datasource
-     * @returns {Databridge} a reference to self to facilitate function chaning.
+     * @returns {Databridge} a reference to self to facilitate function chaining.
      */
     registerDatasource(){
         let args = validateParams.assert(arguments, [{

--- a/test/test.js
+++ b/test/test.js
@@ -33,7 +33,7 @@ QUnit.begin(function(){
 
 /**
  * An object containing dummy data. The pieces of dummy data are indexed by
- * names, and each peice of dummy data is itself an object indexed by `desc` (a
+ * names, and each piece of dummy data is itself an object indexed by `desc` (a
  * description) and `val` (the dummy value).
  *
  * This object is re-built before each test
@@ -132,10 +132,10 @@ function dummyDesc(typeName){
 }
 
 /**
- * A function to return the names of all dummy asic types not explicitly
+ * A function to return the names of all dummy basic types not explicitly
  * excluded.
  *
- * @param {...string} typeName - the names of the types to exclide from the
+ * @param {...string} typeName - the names of the types to exclude from the
  * returned list.
  * @returns Array.<string> the names of all the dummy basic types except those
  * excluded by the passed arguments as an array of strings.


### PR DESCRIPTION
Most typos are in comments. I've created a separate commit with a typo fix in a method name for easier reference.